### PR TITLE
fix: set a smaller batch size for clip

### DIFF
--- a/notebooks/finetuner-clip/FinetunerXCLIPBenchmark.ipynb
+++ b/notebooks/finetuner-clip/FinetunerXCLIPBenchmark.ipynb
@@ -302,6 +302,7 @@
     "    run_name='clip-run',\n",
     "    loss='CLIPLoss', # use CLIPLoss for fine-tuning CLIP model\n",
     "    epochs=5,\n",
+    "    batch_size=64,\n",
     "    learning_rate= 1e-6,\n",
     "    device='cuda',\n",
     ")"


### PR DESCRIPTION
we observed we can not reproduce CLIP Benchmark anymore. In the end we realised it is because of the "automatic selection of batch size" feature we introduced in finetuner 0.7.3. 

If user did not specify a batch size, we use the maximum batch size you can utilize on the current GPU. Which increase default CLIP batch size from 64 to 256. This is lead to insufficient training of the CLIP model given a  small dataset.

In this PR, I manually set the batch size to 64 and now i can reproduce results again.