### PR TITLE
Fix URLS in notebook

### DIFF
--- a/notebooks/heatmaps/colbert_heatmaps.ipynb
+++ b/notebooks/heatmaps/colbert_heatmaps.ipynb
@@ -171,7 +171,7 @@
    "source": [
     "### Download utilities\n",
     "\n",
-    "This file contains code for accessing the token-level of the Jina Reranker API and using `matplotlib` to generate heat maps. If you need to, you can [download it directly from GitHub](https://raw.githubusercontent.com/jina-ai/workshops/docs-heatmaps/notebooks/heatmaps/jina_colbert_heatmaps.py)."
+    "This file contains code for accessing the token-level of the Jina Reranker API and using `matplotlib` to generate heat maps. If you need to, you can [download it directly from GitHub](https://raw.githubusercontent.com/jina-ai/workshops/main/notebooks/heatmaps/jina_colbert_heatmaps.py)."
    ]
   },
   {
@@ -188,7 +188,7 @@
    },
    "outputs": [],
    "source": [
-    "!wget https://raw.githubusercontent.com/jina-ai/workshops/docs-heatmaps/notebooks/heatmaps/jina_colbert_heatmaps.py"
+    "!wget https://raw.githubusercontent.com/jina-ai/workshops/main/notebooks/heatmaps/jina_colbert_heatmaps.py"
    ]
   },
   {


### PR DESCRIPTION
2 URLs in the notebook pointed to the dead branch. This is now fixed.